### PR TITLE
use the vault name as tray icon tooltip

### DIFF
--- a/main.js
+++ b/main.js
@@ -161,7 +161,7 @@ const addQuickNote = () => {
       ]);
     tray = new Tray(obsidianIcon);
     tray.setContextMenu(contextMenu);
-    tray.setToolTip("Obsidian");
+    tray.setToolTip(plugin.app.vault.getName() ?? "Obsidian");
     tray.on("click", () => toggleWindows(false));
   };
 


### PR DESCRIPTION
I think it will be easier to differenciate the vaults if we set their tray icon tooltips to coresponding vault names.