### PR TITLE
Expose Windowing APIs to Other Plugins

### DIFF
--- a/main.js
+++ b/main.js
@@ -478,6 +478,11 @@ class TrayPlugin extends obsidian.Plugin {
     cleanup();
   }
 
+  getWindows = getWindows;
+  showWindows = showWindows;
+  hideWindows = hideWindows;
+  toggleWindows = toggleWindows;
+
   async loadSettings() {
     const DEFAULT_SETTINGS = OPTIONS.map((opt) => ({ [opt.key]: opt.default }));
     this.settings = Object.assign(...DEFAULT_SETTINGS, await this.loadData());

--- a/main.js
+++ b/main.js
@@ -478,6 +478,7 @@ class TrayPlugin extends obsidian.Plugin {
     cleanup();
   }
 
+  getCurrentWindow = getCurrentWindow
   getWindows = getWindows;
   showWindows = showWindows;
   hideWindows = hideWindows;


### PR DESCRIPTION
This is a very short PR. I just expose the following functions at the plugin object:

# Exposed API:
- getWindows()
- showWindows()
- hideWindows()
- toggleWindows()

# Why?

Make it so that other plugins can make use of your Windowing API. An example usage would be within DataviewJS or Templater to switch window focus back when another plugin like Teleprompter switches focus away.

# Example usage:

Say you work in customer service, and you want to open a teleprompter in one window and a modal form in another. The teleprompter window tells you what questions to ask, and you fill out the modal form

```js
# Customer Contact Form:
<%-*
// templater script:
const teleprompter = app.plugins.plugins.teleprompter.api
const modalForms = app.plugins.plugins.modalForms.api

const tray = app.plugins.plugins.tray

const thisWindow = tray.getCurrentWindow()

// open Teleprompter in another window
await teleprompter.open({
  file: "Customer Questionaire",
  placement: "window",
  pin: true,
  play: true
});

// return focus back to this window
thisWindow.focus()

const responses = await modalForm.openForm("customer-responses");

teleprompter.close()
%>
```