### PR TITLE
fix: #14 taskbar icon doesn't open minimized Obsidian

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,6 +42,17 @@ const obsidian = require("obsidian"),
   { nativeImage, BrowserWindow } = require("electron").remote,
   { getCurrentWindow, globalShortcut } = require("electron").remote;
 
+app.on("second-instance", (e) => {
+  const win2 = BrowserWindow.getAllWindows()[0];
+  // prevents "flashing" (quick open->close Obsidian start window)
+  win2.setOpacity(0.0); 
+  win2.once("ready-to-show", () => {
+    win2.close();
+  });
+  getCurrentWindow().show();
+  getCurrentWindow().focus();
+});
+
 const vaultWindows = new Set(),
   maximizedWindows = new Set(),
   getWindows = () => [...vaultWindows],


### PR DESCRIPTION
> [!IMPORTANT]
> The "Run in background" option must be enabled.
>
> ![Снимок экрана 2025-01-11 045400](https://github.com/user-attachments/assets/0971a24b-324e-495b-8128-5af719d1604e)

## Before
When the application is minimized to the tray, if you launch it not through the tray icon, but through a shortcut (create a new process) - the Obsidian start window opens: 

https://github.com/user-attachments/assets/fd8affae-dcb6-4b80-937c-c73324373373

## After
When you launch the Obsidian minimized to tray through a shortcut, the main window is shown: 


https://github.com/user-attachments/assets/b078349e-f77e-4862-aab5-be3dec693f88
