### PR TITLE
feat: #49 Add Obsidian protocol URI handler for toggling windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-/**
+/*
  * obsidian-tray v0.3.5
  * (c) 2023 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
  * (https://github.com/dragonwocky/obsidian-tray/) under the MIT license
@@ -15,6 +15,7 @@ const LOG_PREFIX = "obsidian-tray",
   LOG_TRAY_ICON = "creating tray icon",
   LOG_REGISTER_HOTKEY = "registering hotkey",
   LOG_UNREGISTER_HOTKEY = "unregistering hotkey",
+  LOG_REGISTER_HANDLER = "registering URI handler",
   ACTION_QUICK_NOTE = "Quick Note",
   ACTION_SHOW = "Show Vault",
   ACTION_HIDE = "Hide Vault",
@@ -247,6 +248,16 @@ const registerHotkeys = () => {
     } catch {}
   };
 
+const registerURIHandlers = (obsidian) => {
+    log(LOG_REGISTER_HANDLER);
+    try {
+      obsidian.registerObsidianProtocolHandler("tray/toggleWindows", () => {
+        toggleWindows();
+      });
+    } catch {}
+  }
+;
+
 const OPTIONS = [
   "Window management",
   {
@@ -453,6 +464,7 @@ class TrayPlugin extends obsidian.Plugin {
     plugin = this;
     createTrayIcon();
     registerHotkeys();
+    registerURIHandlers(this);
     setLaunchOnStartup();
     observeWindows();
     if (settings.runInBackground) interceptWindowClose();


### PR DESCRIPTION
This adds the URI handler `obsidian://tray/toggleWindows`, which replicates the functionality of the 'toggle window focus' hotkey.

As far as I know, until Obsidian downstreams Electron/Chromium's xdg-desktop-portal global shortcut implementation, this is the only way to get a global shortcut to toggle the vault on Linux Wayland DEs with no X11 legacy shortcut support, like GNOME. You would just bind a shortcut to `xdg-open obsidian://tray/toggleWindows`. Should solve #49.