### PR TITLE
fix: update documentation URL for Electron accelerator format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ toggle window visibility and create quick notes from anywhere in your operating 
 
 ### Window management
 
-| Option                     | Description                                                                                                                                                                                              | Default                        |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| Launch on startup          | Open Obsidian automatically whenever you log into your computer.                                                                                                                                         | Disabled                       |
-| Hide on launch             | Minimises Obsidian automatically whenever the app is launched. If the "Run in background" option is enabled, windows will be hidden to the system tray/menubar instead of minimised to the taskbar/dock. | Disabled                       |
-| Run in background          | Hide the app and continue to run it in the background instead of quitting it when pressing the window close button or toggle focus hotkey.                                                               | Disabled                       |
-| Hide taskbar icon          | Hides the window's icon from from the dock/taskbar. This may not work on Linux-based OSes.                                                                                                               | Disabled                       |
-| Create tray icon           | Add an icon to your system tray/menubar to bring hidden Obsidian windows back into focus on click or force a full quit/relaunch of the app through the right-click menu.                                 | Enabled                        |
-| Tray icon image            | Set the image used by the tray/menubar icon. Recommended size: 16x16                                                                                                                                     | ![](obsidian.png)              |
-| Tray icon tooltip          | Set a title to identify the tray/menubar icon by. The `{{vault}}` placeholder will be replaced by the vault name.                                                                                        | `{{vault}} \| Obsidian`        |
-| Toggle window focus hotkey | This hotkey is registered globally and will be detected even if Obsidian does not have keyboard focus. Format: [Electron accelerator](https://www.electronjs.org/docs/latest/api/accelerator)            | <kbd>CmdOrCtrl+Shift+Tab</kbd> |
+| Option                     | Description                                                                                                                                                                                                                       | Default                        |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------------------------ |
+| Launch on startup          | Open Obsidian automatically whenever you log into your computer.                                                                                                                                                                  | Disabled                       |
+| Hide on launch             | Minimises Obsidian automatically whenever the app is launched. If the "Run in background" option is enabled, windows will be hidden to the system tray/menubar instead of minimised to the taskbar/dock.                          | Disabled                       |
+| Run in background          | Hide the app and continue to run it in the background instead of quitting it when pressing the window close button or toggle focus hotkey.                                                                                        | Disabled                       |
+| Hide taskbar icon          | Hides the window's icon from from the dock/taskbar. This may not work on Linux-based OSes.                                                                                                                                        | Disabled                       |
+| Create tray icon           | Add an icon to your system tray/menubar to bring hidden Obsidian windows back into focus on click or force a full quit/relaunch of the app through the right-click menu.                                                          | Enabled                        |
+| Tray icon image            | Set the image used by the tray/menubar icon. Recommended size: 16x16                                                                                                                                                              | ![](obsidian.png)              |
+| Tray icon tooltip          | Set a title to identify the tray/menubar icon by. The `{{vault}}` placeholder will be replaced by the vault name.                                                                                                                 | `{{vault}} \| Obsidian`        |
+| Toggle window focus hotkey | This hotkey is registered globally and will be detected even if Obsidian does not have keyboard focus. Format: [Electron accelerator](https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts#accelerators)            | <kbd>CmdOrCtrl+Shift+Tab</kbd> |
 
 The `Relaunch Obsidian` and `Close Vault` actions can be triggered from the tray/menubar context menu,
 or with the in-app command palette (search for "Tray: Relaunch Obsidian" or "Tray: Close Vault").
@@ -25,11 +25,11 @@ Hotkeys can be assigned to the commands via Obsidian's built-in hotkey manager.
 
 ### Quick notes
 
-| Option                 | Description                                                                                                                                                                                   | Default                      |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| Quick note location    | New quick notes will be placed in this folder.                                                                                                                                                |                              |
-| Quick note date format | New quick notes will use a filename of this pattern. Format: [Moment.js format string](https://momentjs.com/docs/#/displaying/format/)                                                        | `YYYY-MM-DD`                 |
-| Quick note hotkey      | This hotkey is registered globally and will be detected even if Obsidian does not have keyboard focus. Format: [Electron accelerator](https://www.electronjs.org/docs/latest/api/accelerator) | <kbd>CmdOrCtrl+Shift+Q</kbd> |
+| Option                 | Description                                                                                                                                                                                                            | Default                      |
+| ---------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ---------------------------- |
+| Quick note location    | New quick notes will be placed in this folder.                                                                                                                                                                         |                              |
+| Quick note date format | New quick notes will use a filename of this pattern. Format: [Moment.js format string](https://momentjs.com/docs/#/displaying/format/)                                                                                 | `YYYY-MM-DD`                 |
+| Quick note hotkey      | This hotkey is registered globally and will be detected even if Obsidian does not have keyboard focus. Format: [Electron accelerator](https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts#accelerators) | <kbd>CmdOrCtrl+Shift+Q</kbd> |
 
 ## Installation
 

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ const LOG_PREFIX = "obsidian-tray",
   ACCELERATOR_FORMAT = `
     This hotkey is registered globally and will be detected even if Obsidian does
     not have keyboard focus. Format:
-    <a href="https://www.electronjs.org/docs/latest/api/accelerator" target="_blank" rel="noopener">
+    <a href="https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts#accelerators" target="_blank" rel="noopener">
     Electron accelerator</a>
   `,
   MOMENT_FORMAT = `


### PR DESCRIPTION
I just installed this plugin and the first thing I did was click the Electron accelerator format documentation link, which resulted in a 404.

---

The current URL is outdated (404).  Accelerator documentation is now in the keyboard shortcuts section of the tutorial.
